### PR TITLE
Use the updated URL from TFL to pull in timetables

### DIFF
--- a/app/models/rb6_xml.rb
+++ b/app/models/rb6_xml.rb
@@ -7,7 +7,7 @@ require 'open-uri'
 class RB6XML
   TIMETABLES_DIR = "#{Rails.root}/tmp/timetables".freeze
   TIMETABLES_ZIP = 'journey-planner-timetables.zip'.freeze
-  TIMETABLES_BASE_URL = "http://data.tfl.gov.uk/tfl/syndication/feeds/#{TIMETABLES_ZIP}".freeze
+  TIMETABLES_BASE_URL = "http://tfl.gov.uk/tfl/syndication/feeds/#{TIMETABLES_ZIP}".freeze
   TIMETABLES_QUERY_STRING = "?app_id=#{ENV['TFL_APP_ID']}&app_key=#{ENV['TFL_APP_KEY']}".freeze
   TIMETABLES_URL = "#{TIMETABLES_BASE_URL}#{TIMETABLES_QUERY_STRING}".freeze
 

--- a/spec/graphql_query_spec.rb
+++ b/spec/graphql_query_spec.rb
@@ -44,6 +44,7 @@ RSpec.describe 'graphql', type: :request do
               { 'departureTime' => '1927',  'arrivalTime' => '2010' },
               { 'departureTime' => '1947',  'arrivalTime' => '2030' },
               { 'departureTime' => '2007',  'arrivalTime' => '2048' },
+              { 'departureTime' => '0748',  'arrivalTime' => '0824' },
               { 'departureTime' => '2027',  'arrivalTime' => '2110' },
               { 'departureTime' => '2047',  'arrivalTime' => '2127' },
               { 'departureTime' => '2107',  'arrivalTime' => '2150' },


### PR DESCRIPTION
Prior to this fix, the timetables were not being pulled in anymore from
TFL.

Also, the timetables under the updated URL contain the previously
missing 0748 from Wandsworth to Blackfriars, so this fixes #22.