### PR TITLE
Remove 0748 ferry from test

### DIFF
--- a/spec/graphql_query_spec.rb
+++ b/spec/graphql_query_spec.rb
@@ -31,7 +31,6 @@ RSpec.describe 'graphql', type: :request do
               { 'departureTime' => '0617',  'arrivalTime' => '0700' },
               { 'departureTime' => '0647',  'arrivalTime' => '0730' },
               { 'departureTime' => '0717',  'arrivalTime' => '0800' },
-              { 'departureTime' => '0748',  'arrivalTime' => '0824' },
               { 'departureTime' => '0802',  'arrivalTime' => '0848' },
               { 'departureTime' => '0837',  'arrivalTime' => '0922' },
               { 'departureTime' => '0907',  'arrivalTime' => '0953' },


### PR DESCRIPTION
The 0748 express ferry from Wandsworth is missing for some reason in the
TFL data.  It has been missing consistently for a couple of weeks.

I've raised
https://techforum.tfl.gov.uk/t/river-rb6-timetable-in-journey-planner-is-missing-a-journey/1151
for this, but no replies yet.

To keep the tests passing I have removed the ferry from the expected
test data for now.